### PR TITLE
CC-1838: Disable integration test for deprecated repo in Jenkins build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 dockerfile {
     dockerRepos = ['confluentinc/cp-kafka-connect-base', 'confluentinc/cp-kafka-connect', 'confluentinc/cp-enterprise-replicator']
     dockerRegistry = '368821881613.dkr.ecr.us-west-2.amazonaws.com/'
-    dockerUpstreamTag = '4.1.x-71'
+    dockerUpstreamTag = '4.0.x-92'
     mvnPhase = 'package'
     mvnSkipDeploy = true
     nodeLabel = 'docker-oraclejdk8-compose'


### PR DESCRIPTION
Disable integration test in Jenkinsfile to this branch to fix the build issues. Build failures: https://jenkins.confluent.io/job/confluentinc/job/kafka-connect-images/job/4.0.x/203/

Signed-off-by: Arjun Satish <arjun@confluent.io>