### PR TITLE
CC-2922: Update upstream tag for cp-kafka to fix build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ dockerfile {
     dockerRepos = ['confluentinc/cp-kafka-connect-base', 'confluentinc/cp-kafka-connect', 'confluentinc/cp-enterprise-replicator']
     dockerPullDeps = ['confluentinc/cp-kafka']
     dockerRegistry = '368821881613.dkr.ecr.us-west-2.amazonaws.com/'
-    dockerUpstreamTag = '4.1.x-71'
+    dockerUpstreamTag = '4.1.x-352'
     mvnPhase = 'package'
     mvnSkipDeploy = true
     nodeLabel = 'docker-oraclejdk8-compose'


### PR DESCRIPTION
Trying to address a recent [Jenkins job failure](https://jenkins.confluent.io/job/confluentinc/job/kafka-connect-images/job/4.1.x/135/console) with this (JIRA issue [here](https://confluentinc.atlassian.net/browse/CC-2922)).

Not sure what state this repo is in but we got a testbreak notification so taking steps to try to fix things. If this isn't meant to be ready yet then we can close this PR.