### PR TITLE
Switch to latest tag as it is published now

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 dockerfile {
     dockerRepos = ['confluentinc/cp-kafka-connect-base', 'confluentinc/cp-kafka-connect', 'confluentinc/cp-enterprise-replicator']
     dockerRegistry = '368821881613.dkr.ecr.us-west-2.amazonaws.com/'
-    dockerUpstreamTag = '4.0.x-434'
+    dockerUpstreamTag = '4.0.x-latest'
     mvnPhase = 'package'
     mvnSkipDeploy = true
     nodeLabel = 'docker-oraclejdk8-compose'


### PR DESCRIPTION
We are publishing the -latest tag now, so we should use that to avoid having to update this manually. 