### PR TITLE
ST-2476: Updating the readme and pom files to reflect the renaming of this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Docker images for Kafka Connect
+# Docker images for Kafka Replicator
 
-This repo provides build files for [Connect](https://www.confluent.io/connectors/) Docker images.
+This repo provides build files for [Replicator](https://www.confluent.io/confluent-replicator) Docker images.
 
 ## Properties
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,10 +26,10 @@
     </parent>
 
     <groupId>io.confluent.kafka-connect-images</groupId>
-    <artifactId>kafka-connect-images-parent</artifactId>
+    <artifactId>kafka-replicator-images-parent</artifactId>
     <packaging>pom</packaging>
-    <name>Kafka Connect Replicator Docker Images</name>
-    <description>Build files for Confluent's Kafka Connect Replicator Docker images</description>
+    <name>Kafka Replicator Docker Images</name>
+    <description>Build files for Confluent's Kafka Replicator Docker images</description>
     <version>5.4.0-SNAPSHOT</version>
 
     <modules>
@@ -38,6 +38,6 @@
     </modules>
 
     <properties>
-        <component.name>kafka-connect-replicator</component.name>
+        <component.name>kafka-replicator</component.name>
     </properties>
 </project>

--- a/replicator-executable/pom.xml
+++ b/replicator-executable/pom.xml
@@ -22,7 +22,7 @@
 
     <parent>
         <groupId>io.confluent.kafka-connect-images</groupId>
-        <artifactId>kafka-connect-images-parent</artifactId>
+        <artifactId>kafka-replicator-images-parent</artifactId>
         <version>5.4.0-SNAPSHOT</version>
     </parent>
 

--- a/replicator/pom.xml
+++ b/replicator/pom.xml
@@ -22,7 +22,7 @@
 
     <parent>
         <groupId>io.confluent.kafka-connect-images</groupId>
-        <artifactId>kafka-connect-images-parent</artifactId>
+        <artifactId>kafka-replicator-images-parent</artifactId>
         <version>5.4.0-SNAPSHOT</version>
     </parent>
 

--- a/replicator/setup.py
+++ b/replicator/setup.py
@@ -7,7 +7,7 @@ setuptools.setup(
     author="Confluent, Inc.",
     author_email="replicator@confluent.io",
     description='Kafka Replicator docker image tests',
-    url="https://github.com/confluentinc/kafka-connect-images",
+    url="https://github.com/confluentinc/kafka-replicator-images",
     dependency_links=open("requirements.txt").read().split("\n"),
     packages=['test'],
     include_package_data=True,


### PR DESCRIPTION
This repo was renamed from kafka-connect-images to kafka-replicator-images  so we need to update the readme to reflect that and make some minor changes to the name of the parent pom file. This repo now only has replicator images, and the connect images are in the kafka-images repo.