### PR TITLE
ST-2560: Adding support for building debian and rhel images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,4 +12,6 @@ dockerfile {
     dockerPullDeps = ['confluentinc/cp-base-new', 'confluentinc/cp-server-connect-base']
     usePackages = true
     cron = '' // Disable the cron because this job requires parameters
+    cpImages = true
+    osTypes = ['deb8', 'rhel8']
 }

--- a/replicator-executable/Dockerfile.deb8
+++ b/replicator-executable/Dockerfile.deb8
@@ -1,0 +1,44 @@
+#
+# Copyright 2019 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG DOCKER_UPSTREAM_REGISTRY
+ARG DOCKER_UPSTREAM_TAG=latest
+ARG DOCKER_TAG
+
+FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-enterprise-replicator:${DOCKER_TAG}
+
+ARG PROJECT_VERSION
+ARG ARTIFACT_ID
+ 
+# Make sure you use an appropriate contact address.
+LABEL MAINTAINER partner-support@confluent.io
+LABEL io.confluent.docker=true
+ARG COMMIT_ID=unknown
+LABEL io.confluent.docker.git.id=$COMMIT_ID
+ARG BUILD_NUMBER=-1
+LABEL io.confluent.docker.build.number=$BUILD_NUMBER
+ARG CONFLUENT_VERSION
+ARG CONFLUENT_PACKAGES_REPO
+ARG CONFLUENT_PLATFORM_LABEL
+ARG CONFLUENT_DEB_VERSION
+ARG ALLOW_UNSIGNED
+
+ENV COMPONENT=replicator
+
+VOLUME ["/etc/${COMPONENT}/secrets"]
+
+COPY include/etc/confluent/docker /etc/confluent/docker
+
+CMD ["/etc/confluent/docker/run"]

--- a/replicator-executable/Dockerfile.rhel8
+++ b/replicator-executable/Dockerfile.rhel8
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 ARG DOCKER_UPSTREAM_REGISTRY
-ARG DOCKER_UPSTREAM_TAG=latest
+ARG DOCKER_UPSTREAM_TAG=rhel8-latest
 ARG DOCKER_TAG
 
 FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-enterprise-replicator:${DOCKER_TAG}
@@ -23,17 +23,13 @@ ARG PROJECT_VERSION
 ARG ARTIFACT_ID
  
 # Make sure you use an appropriate contact address.
-MAINTAINER partner-support@confluent.io
+LABEL maintainer="partner-support@confluent.io"
 LABEL io.confluent.docker=true
 ARG COMMIT_ID=unknown
 LABEL io.confluent.docker.git.id=$COMMIT_ID
 ARG BUILD_NUMBER=-1
 LABEL io.confluent.docker.build.number=$BUILD_NUMBER
-ARG CONFLUENT_VERSION
-ARG CONFLUENT_PACKAGES_REPO
-ARG CONFLUENT_PLATFORM_LABEL
-ARG CONFLUENT_DEB_VERSION
-ARG ALLOW_UNSIGNED
+
 
 ENV COMPONENT=replicator
 

--- a/replicator-executable/include/etc/confluent/docker/log4j.properties.template
+++ b/replicator-executable/include/etc/confluent/docker/log4j.properties.template
@@ -11,7 +11,7 @@ log4j.logger.org.reflections=ERROR
 
 {% if env['REPLICATOR_LOG4J_LOGGERS'] %}
 {% set loggers = parse_log4j_loggers(env['REPLICATOR_LOG4J_LOGGERS']) %}
-{% for logger,loglevel in loggers.iteritems() %}
+{% for logger,loglevel in loggers.items() %}
 log4j.logger.{{logger}}={{loglevel}}
 {% endfor %}
 {% endif %}

--- a/replicator/Dockerfile.deb8
+++ b/replicator/Dockerfile.deb8
@@ -22,7 +22,7 @@ ARG PROJECT_VERSION
 ARG ARTIFACT_ID
  
 # Make sure you use an appropriate contact address.
-MAINTAINER partner-support@confluent.io
+LABEL MAINTAINER partner-support@confluent.io
 LABEL io.confluent.docker=true
 ARG COMMIT_ID=unknown
 LABEL io.confluent.docker.git.id=$COMMIT_ID

--- a/replicator/Dockerfile.rhel8
+++ b/replicator/Dockerfile.rhel8
@@ -1,0 +1,39 @@
+#
+# Copyright 2019 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG DOCKER_UPSTREAM_REGISTRY
+ARG DOCKER_UPSTREAM_TAG=rhel8-latest
+
+FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-server-connect-base:${DOCKER_UPSTREAM_TAG}
+
+ARG PROJECT_VERSION
+ARG ARTIFACT_ID
+ 
+# Make sure you use an appropriate contact address.
+LABEL maintainer="partner-support@confluent.io"
+LABEL io.confluent.docker=true
+ARG COMMIT_ID=unknown
+LABEL io.confluent.docker.git.id=$COMMIT_ID
+ARG BUILD_NUMBER=-1
+LABEL io.confluent.docker.build.number=$BUILD_NUMBER
+ARG CONFLUENT_VERSION
+
+RUN echo "===> Installing Replicator ..." \
+    && yum -q -y update \
+    && yum install -y \
+        confluent-kafka-connect-replicator-${CONFLUENT_VERSION} \
+    && echo "===> Cleaning up ..."  \
+    && yum clean all \
+    && rm -rf /tmp/*


### PR DESCRIPTION
Renamed the Dockerfile to Dockerfile.deb8, and added Dockerfile.rhel8 for each image. The images now use cp-base-new because we are building multiple versions of the new base image, one of which is the existing deb8 version which will still get used here. So to clarify, this will not upgrade the debian images to use a new version of debian even though we are using cp-base-new.

I have tested the debian images locally and it worked with cp-demo. Testing of the rhel images with cp-demo is still on going.