### PR TITLE
ST-2811: Adding support for running as appuser on rhel image

### DIFF
--- a/replicator-executable/Dockerfile.rhel8
+++ b/replicator-executable/Dockerfile.rhel8
@@ -30,11 +30,10 @@ LABEL io.confluent.docker.git.id=$COMMIT_ID
 ARG BUILD_NUMBER=-1
 LABEL io.confluent.docker.build.number=$BUILD_NUMBER
 
-
 ENV COMPONENT=replicator
 
 VOLUME ["/etc/${COMPONENT}/secrets"]
 
-COPY include/etc/confluent/docker /etc/confluent/docker
+COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker
 
 CMD ["/etc/confluent/docker/run"]

--- a/replicator/Dockerfile.rhel8
+++ b/replicator/Dockerfile.rhel8
@@ -30,6 +30,8 @@ ARG BUILD_NUMBER=-1
 LABEL io.confluent.docker.build.number=$BUILD_NUMBER
 ARG CONFLUENT_VERSION
 
+USER root
+
 RUN echo "===> Installing Replicator ..." \
     && yum -q -y update \
     && yum install -y \
@@ -37,3 +39,5 @@ RUN echo "===> Installing Replicator ..." \
     && echo "===> Cleaning up ..."  \
     && yum clean all \
     && rm -rf /tmp/*
+
+USER appuser


### PR DESCRIPTION
The base image now has a user account "appuser" and this change will make the service run as that user instead of root.

The PR build for this will not succeed until the new version of the base image is published with the appuser.

I tested these changes by building the image and running cp-demo.