### PR TITLE
ST-2560: Adding labels required by RedHat container registry

### DIFF
--- a/replicator-executable/Dockerfile.deb8
+++ b/replicator-executable/Dockerfile.deb8
@@ -21,12 +21,11 @@ FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-enterprise-replicator:${DOCKER_T
 
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
- 
-# Make sure you use an appropriate contact address.
-LABEL MAINTAINER partner-support@confluent.io
+
+LABEL maintainer="partner-support@confluent.io"
 LABEL io.confluent.docker=true
-ARG COMMIT_ID=unknown
-LABEL io.confluent.docker.git.id=$COMMIT_ID
+ARG GIT_COMMIT
+LABEL io.confluent.docker.git.id=$GIT_COMMIT
 ARG BUILD_NUMBER=-1
 LABEL io.confluent.docker.build.number=$BUILD_NUMBER
 ARG CONFLUENT_VERSION

--- a/replicator-executable/Dockerfile.rhel8
+++ b/replicator-executable/Dockerfile.rhel8
@@ -21,14 +21,19 @@ FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-enterprise-replicator:${DOCKER_T
 
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
- 
-# Make sure you use an appropriate contact address.
+ARG GIT_COMMIT
+
 LABEL maintainer="partner-support@confluent.io"
+LABEL vendor="Confluent"
+LABEL version=$GIT_COMMIT
+LABEL release=$PROJECT_VERSION
+LABEL name=$ARTIFACT_ID
+LABEL summary="Confluent Replicator allows you to easily and reliably replicate topics from one Apache Kafka® cluster to another."
 LABEL io.confluent.docker=true
-ARG COMMIT_ID=unknown
-LABEL io.confluent.docker.git.id=$COMMIT_ID
+LABEL io.confluent.docker.git.id=$GIT_COMMIT
 ARG BUILD_NUMBER=-1
 LABEL io.confluent.docker.build.number=$BUILD_NUMBER
+LABEL io.confluent.docker.git.repo="confluentinc/kafka-replicator-images"
 
 ENV COMPONENT=replicator
 

--- a/replicator/Dockerfile.deb8
+++ b/replicator/Dockerfile.deb8
@@ -20,12 +20,11 @@ FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-server-connect-base:${DOCKER_UPS
 
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
- 
-# Make sure you use an appropriate contact address.
-LABEL MAINTAINER partner-support@confluent.io
+
+LABEL maintainer="partner-support@confluent.io"
 LABEL io.confluent.docker=true
-ARG COMMIT_ID=unknown
-LABEL io.confluent.docker.git.id=$COMMIT_ID
+ARG GIT_COMMIT
+LABEL io.confluent.docker.git.id=$GIT_COMMIT
 ARG BUILD_NUMBER=-1
 LABEL io.confluent.docker.build.number=$BUILD_NUMBER
 ARG CONFLUENT_VERSION

--- a/replicator/Dockerfile.rhel8
+++ b/replicator/Dockerfile.rhel8
@@ -20,14 +20,20 @@ FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-server-connect-base:${DOCKER_UPS
 
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
- 
-# Make sure you use an appropriate contact address.
+ARG GIT_COMMIT
+
 LABEL maintainer="partner-support@confluent.io"
+LABEL vendor="Confluent"
+LABEL version=$GIT_COMMIT
+LABEL release=$PROJECT_VERSION
+LABEL name=$ARTIFACT_ID
+LABEL summary="Confluent Replicator allows you to easily and reliably replicate topics from one Apache Kafka® cluster to another."
 LABEL io.confluent.docker=true
-ARG COMMIT_ID=unknown
 LABEL io.confluent.docker.git.id=$COMMIT_ID
 ARG BUILD_NUMBER=-1
 LABEL io.confluent.docker.build.number=$BUILD_NUMBER
+LABEL io.confluent.docker.git.repo="confluentinc/kafka-replicator-images"
+
 ARG CONFLUENT_VERSION
 
 USER root


### PR DESCRIPTION
These labels are required to pass the RedHat certification process for uploading images to the container registry.