### PR TITLE
Temporarily remove installing OS confluent-kafka-connect-replicator packages

### DIFF
--- a/replicator/Dockerfile.deb8
+++ b/replicator/Dockerfile.deb8
@@ -41,6 +41,5 @@ RUN echo "===> Installing Replicator ..." \
     && cat /etc/apt/sources.list \
     && apt-get install -y apt-transport-https \
     && apt-get -qq update \
-    && apt-get install -y confluent-kafka-connect-replicator=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     && echo "===> Cleaning up ..."  \
     && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/*

--- a/replicator/Dockerfile.ubi8
+++ b/replicator/Dockerfile.ubi8
@@ -40,8 +40,6 @@ USER root
 
 RUN echo "===> Installing Replicator ..." \
     && yum -q -y update \
-    && yum install -y \
-        confluent-kafka-connect-replicator-${CONFLUENT_VERSION} \
     && echo "===> Cleaning up ..."  \
     && yum clean all \
     && rm -rf /tmp/*


### PR DESCRIPTION
The connect team is in the process of decoupling connectors from the platform build. So these connect OS packages have been removed from 6.0.0 and no longer exist.

This change is here to get nightly builds of the docker images up and running. The connect team will make a decision later on about how they want to distribute connectors in Docker images.