### PR TITLE
REP-1177 change ownership for directories required by Replicator Executable

### DIFF
--- a/replicator-executable/Dockerfile.ubi8
+++ b/replicator-executable/Dockerfile.ubi8
@@ -41,4 +41,11 @@ VOLUME ["/etc/${COMPONENT}/secrets"]
 
 COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker
 
+USER root
+
+RUN chown appuser:appuser -R /etc/replicator \
+    && chown appuser:appuser -R /etc/kafka-connect-replicator
+
+USER appuser
+
 CMD ["/etc/confluent/docker/run"]


### PR DESCRIPTION
Replicator executable requires that the following dirs are writable by the user starting Replicator:

/etc/replicator
/etc/kafka-connect-replicator

In the new UBI images Replicator is started by appuser which does not have write perms on these dirs. This PR changes ownership of these dirs to the replicator user to address this.