### PR TITLE
MINOR: Update slack channel in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,5 +7,5 @@ dockerfile {
     mvnSkipDeploy = true
     nodeLabel = 'docker-oraclejdk8-compose'
     withPush = true
-    slackChannel = '#connect-warn'
+    slackChannel = '#replicator-alerts'
 }


### PR DESCRIPTION
Connect no longer owns Replicator. Redirecting notifications to `#replicator-alerts`.