### PR TITLE
MINOR: Remove unbounded yum update

### DIFF
--- a/replicator/Dockerfile.ubi8
+++ b/replicator/Dockerfile.ubi8
@@ -39,7 +39,6 @@ ARG CONFLUENT_VERSION
 USER root
 
 RUN echo "===> Installing Replicator ..." \
-    && yum -q -y update \
     && yum install -y \
         confluent-kafka-connect-replicator-${CONFLUENT_VERSION} \
     && echo "===> Cleaning up ..."  \


### PR DESCRIPTION
While looking at the failure here: https://jenkins.confluent.io/job/confluentinc/job/kafka-replicator-images/job/5.5.x/292/

I noticed that we're running an unbounded yum update, which we've removed from the other derived images because this unbounded yum update will update things from the base image we're not expecting. Primarily being the Zulu JDK which caused an issue in the past.

This isn't a direct fix for the issue above (thats to be handled by Redhat), this is me just "doing the right thing" here.