### PR TITLE
REPL-1224 images now automatically include monitoring interceptor and replicator monitoring jars

### DIFF
--- a/replicator-executable/include/etc/confluent/docker/launch
+++ b/replicator-executable/include/etc/confluent/docker/launch
@@ -35,11 +35,14 @@ if [ "x$KAFKA_JMX_PORT" != "x" ]; then
 fi
 
 echo "===> Launching ${COMPONENT} ... "
-# Add external jars to the classpath
+# Add external jars, replicator monitoring and monitoring interceptors to the classpath
 # And this also makes sure that the CLASSPATH does not start with ":/etc/..."
 # because this causes the plugin scanner to scan the entire disk.
-export CLASSPATH="/etc/kafka-connect/jars/*"
-
+if [ -z "$CLASSPATH" ]; then
+    REST_EXTENSION_JAR=$(find /usr/share/java/kafka-connect-replicator/replicator-rest-extension-*jar)
+    MONITORING_INTERCEPTOR_JAR=$(find /usr/share/java/monitoring-interceptors/monitoring-interceptors-*)
+    export CLASSPATH="/etc/kafka-connect/jars/*:$REST_EXTENSION_JAR:$MONITORING_INTERCEPTOR_JAR"
+fi
 
 # File properties
 export ARGS=""

--- a/replicator/Dockerfile.deb8
+++ b/replicator/Dockerfile.deb8
@@ -44,3 +44,7 @@ RUN echo "===> Installing Replicator ..." \
     && apt-get install -y confluent-kafka-connect-replicator=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     && echo "===> Cleaning up ..."  \
     && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/*
+
+COPY include/etc/confluent/docker /etc/confluent/docker
+
+CMD ["/etc/confluent/docker/run"]

--- a/replicator/Dockerfile.ubi8
+++ b/replicator/Dockerfile.ubi8
@@ -45,4 +45,8 @@ RUN echo "===> Installing Replicator ..." \
     && yum clean all \
     && rm -rf /tmp/*
 
+COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker
+
 USER appuser
+
+CMD ["/etc/confluent/docker/run"]

--- a/replicator/include/etc/confluent/docker/apply-mesos-overrides
+++ b/replicator/include/etc/confluent/docker/apply-mesos-overrides
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Copyright 2019 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Mesos DC/OS docker deployments will have HOST and PORT0 
+# set for the proxying of the service.
+# 
+# Use those values provide things we know we'll need.
+
+[ -n "${HOST:-}" ] && [ -z "${CONNECT_REST_ADVERTISED_HOST_NAME:-}" ] && \
+	export CONNECT_REST_ADVERTISED_HOST_NAME=$HOST || true
+
+[ -n "${PORT0:-}" ] && [ -z "${CONNECT_REST_ADVERTISED_PORT:-}" ] && \
+	export CONNECT_REST_ADVERTISED_PORT=$PORT0 || true
+
+# And default to 8083, which MUST match the containerPort specification
+# in the Mesos package for this service.
+[ -z "${CONNECT_REST_PORT:-}" ] && \
+	export CONNECT_REST_PORT=8083 || true
+

--- a/replicator/include/etc/confluent/docker/configure
+++ b/replicator/include/etc/confluent/docker/configure
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Copyright 2019 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+. /etc/confluent/docker/bash-config
+
+dub ensure CONNECT_BOOTSTRAP_SERVERS
+dub ensure CONNECT_GROUP_ID
+dub ensure CONNECT_CONFIG_STORAGE_TOPIC
+dub ensure CONNECT_OFFSET_STORAGE_TOPIC
+dub ensure CONNECT_STATUS_STORAGE_TOPIC
+dub ensure CONNECT_KEY_CONVERTER
+dub ensure CONNECT_VALUE_CONVERTER
+# This is required to avoid config bugs. You should set this to a value that is
+# resolvable by all containers.
+dub ensure CONNECT_REST_ADVERTISED_HOST_NAME
+
+# Default to 8083, which matches the mesos-overrides. This is here in case we extend the containers to remove the mesos overrides.
+if [ -z "$CONNECT_REST_PORT" ]; then
+  export CONNECT_REST_PORT=8083
+fi
+
+# Fix for https://issues.apache.org/jira/browse/KAFKA-3988
+if [[ ${CONNECT_INTERNAL_KEY_CONVERTER-} == "org.apache.kafka.connect.json.JsonConverter" ]] || [[ ${CONNECT_INTERNAL_VALUE_CONVERTER-} == "org.apache.kafka.connect.json.JsonConverter" ]]
+then
+  export CONNECT_INTERNAL_KEY_CONVERTER_SCHEMAS_ENABLE=false
+  export CONNECT_INTERNAL_VALUE_CONVERTER_SCHEMAS_ENABLE=false
+fi
+
+if [[ $CONNECT_KEY_CONVERTER == "io.confluent.connect.avro.AvroConverter" ]]
+then
+  dub ensure CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL
+fi
+
+if [[ $CONNECT_VALUE_CONVERTER == "io.confluent.connect.avro.AvroConverter" ]]
+then
+  dub ensure CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL
+fi
+
+dub path /etc/"${COMPONENT}"/ writable
+
+dub template "/etc/confluent/docker/${COMPONENT}.properties.template" "/etc/${COMPONENT}/${COMPONENT}.properties"
+
+# The connect-distributed script expects the log4j config at /etc/kafka/connect-log4j.properties.
+dub template "/etc/confluent/docker/log4j.properties.template" "/etc/kafka/connect-log4j.properties"

--- a/replicator/include/etc/confluent/docker/ensure
+++ b/replicator/include/etc/confluent/docker/ensure
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Copyright 2019 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+. /etc/confluent/docker/bash-config
+
+echo "===> Check if Kafka is healthy ..."
+
+if [[ -n "${CONNECT_SECURITY_PROTOCOL-}" ]] && [[ $CONNECT_SECURITY_PROTOCOL != "PLAINTEXT" ]]
+then
+
+    cub kafka-ready \
+        "${CONNECT_CUB_KAFKA_MIN_BROKERS:-1}" \
+        "${CONNECT_CUB_KAFKA_TIMEOUT:-40}" \
+        -b "$CONNECT_BOOTSTRAP_SERVERS" \
+        --config /etc/"${COMPONENT}"/kafka-connect.properties
+else
+
+    cub kafka-ready \
+        "${CONNECT_CUB_KAFKA_MIN_BROKERS:-1}" \
+        "${CONNECT_CUB_KAFKA_TIMEOUT:-40}" \
+        -b "$CONNECT_BOOTSTRAP_SERVERS"
+fi

--- a/replicator/include/etc/confluent/docker/kafka-connect.properties.template
+++ b/replicator/include/etc/confluent/docker/kafka-connect.properties.template
@@ -1,0 +1,4 @@
+{% set connect_props = env_to_props('CONNECT_', '') -%}
+{% for name, value in connect_props.items() -%}
+{{name}}={{value}}
+{% endfor -%}

--- a/replicator/include/etc/confluent/docker/launch
+++ b/replicator/include/etc/confluent/docker/launch
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Copyright 2019 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Override this section from the script to include the com.sun.management.jmxremote.rmi.port property.
+if [ -z "$KAFKA_JMX_OPTS" ]; then
+  export KAFKA_JMX_OPTS="-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.authenticate=false  -Dcom.sun.management.jmxremote.ssl=false "
+fi
+
+# The JMX client needs to be able to connect to java.rmi.server.hostname.
+# The default for bridged n/w is the bridged IP so you will only be able to connect from another docker container.
+# For host n/w, this is the IP that the hostname on the host resolves to.
+
+# If you have more that one n/w configured, hostname -i gives you all the IPs,
+# the default is to pick the first IP (or network).
+export KAFKA_JMX_HOSTNAME=${KAFKA_JMX_HOSTNAME:-$(hostname -i | cut -d" " -f1)}
+
+if [ "$KAFKA_JMX_PORT" ]; then
+  # This ensures that the "if" section for JMX_PORT in kafka launch script does not trigger.
+  export JMX_PORT=$KAFKA_JMX_PORT
+  export KAFKA_JMX_OPTS="$KAFKA_JMX_OPTS -Djava.rmi.server.hostname=$KAFKA_JMX_HOSTNAME -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.rmi.port=$JMX_PORT -Dcom.sun.management.jmxremote.port=$JMX_PORT"
+fi
+
+echo "===> Launching ${COMPONENT} ... "
+# Add external jars, replicator monitoring and monitoring interceptors to the classpath
+# And this also makes sure that the CLASSPATH does not start with ":/etc/..."
+# because this causes the plugin scanner to scan the entire disk.
+if [ -z "$CLASSPATH" ]; then
+    REST_EXTENSION_JAR=$(find /usr/share/java/kafka-connect-replicator/replicator-rest-extension-*jar)
+    MONITORING_INTERCEPTOR_JAR=$(find /usr/share/java/monitoring-interceptors/monitoring-interceptors-*)
+    export CLASSPATH="/etc/kafka-connect/jars/*:$REST_EXTENSION_JAR:$MONITORING_INTERCEPTOR_JAR"
+fi
+exec connect-distributed /etc/"${COMPONENT}"/"${COMPONENT}".properties

--- a/replicator/include/etc/confluent/docker/log4j.properties.template
+++ b/replicator/include/etc/confluent/docker/log4j.properties.template
@@ -1,0 +1,24 @@
+
+log4j.rootLogger={{ env["CONNECT_LOG4J_ROOT_LOGLEVEL"] | default('INFO') }}, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern ={{ env["CONNECT_LOG4J_APPENDER_STDOUT_LAYOUT_CONVERSIONPATTERN"] | default('[%d] %p %m (%c)%n') }}
+
+
+{% set default_loggers = {
+	'org.reflections': 'ERROR',
+	'org.apache.zookeeper': 'ERROR',
+	'org.I0Itec.zkclient': 'ERROR'
+} -%}
+
+{% if env['CONNECT_LOG4J_LOGGERS'] %}
+# loggers from CONNECT_LOG4J_LOGGERS env variable
+{% set loggers = parse_log4j_loggers(env['CONNECT_LOG4J_LOGGERS']) %}
+{% else %}
+# default log levels
+{% set loggers = default_loggers %}
+{% endif %}
+{% for logger,loglevel in loggers.items() %}
+log4j.logger.{{logger}}={{loglevel}}
+{% endfor %}

--- a/replicator/include/etc/confluent/docker/run
+++ b/replicator/include/etc/confluent/docker/run
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Copyright 2019 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+. /etc/confluent/docker/bash-config
+
+. /etc/confluent/docker/mesos-setup.sh
+. /etc/confluent/docker/apply-mesos-overrides
+
+echo "===> User"
+id
+
+echo "===> Configuring ..."
+/etc/confluent/docker/configure
+
+echo "===> Running preflight checks ... "
+/etc/confluent/docker/ensure
+
+echo "===> Launching ... "
+exec /etc/confluent/docker/launch


### PR DESCRIPTION
This PR adds replicator monitoring and monitoring interceptor jars to the classpath by default and also allows easy override of the classpath as per https://confluentinc.atlassian.net/browse/REPL-19

Tested by build and running locally