### PR TITLE
REPL-1362: Replace find with ls -d

### DIFF
--- a/replicator-executable/include/etc/confluent/docker/launch
+++ b/replicator-executable/include/etc/confluent/docker/launch
@@ -39,8 +39,8 @@ echo "===> Launching ${COMPONENT} ... "
 # And this also makes sure that the CLASSPATH does not start with ":/etc/..."
 # because this causes the plugin scanner to scan the entire disk.
 if [ -z "$CLASSPATH" ]; then
-    REST_EXTENSION_JAR=$(ls -d /usr/share/java/kafka-connect-replicator/*replicator-rest-extension-*)
-    MONITORING_INTERCEPTOR_JAR=$(ls -d /usr/share/java/monitoring-interceptors/*monitoring-interceptors-*)
+    REST_EXTENSION_JAR=$(ls -d /usr/share/java/kafka-connect-replicator/*replicator-rest-extension-*jar)
+    MONITORING_INTERCEPTOR_JAR=$(ls -d /usr/share/java/monitoring-interceptors/*monitoring-interceptors-*jar)
     export CLASSPATH="/etc/kafka-connect/jars/*:$REST_EXTENSION_JAR:$MONITORING_INTERCEPTOR_JAR"
 fi
 

--- a/replicator-executable/include/etc/confluent/docker/launch
+++ b/replicator-executable/include/etc/confluent/docker/launch
@@ -39,8 +39,8 @@ echo "===> Launching ${COMPONENT} ... "
 # And this also makes sure that the CLASSPATH does not start with ":/etc/..."
 # because this causes the plugin scanner to scan the entire disk.
 if [ -z "$CLASSPATH" ]; then
-    REST_EXTENSION_JAR=$(ls /usr/share/java/kafka-connect-replicator/ | grep "replicator-rest-extension-")
-    MONITORING_INTERCEPTOR_JAR=$(ls /usr/share/java/kafka-connect-replicator/ | grep "monitoring-interceptors-")
+    REST_EXTENSION_JAR=$(ls -d /usr/share/java/kafka-connect-replicator/*replicator-rest-extension-*)
+    MONITORING_INTERCEPTOR_JAR=$(ls -d /usr/share/java/monitoring-interceptors/*monitoring-interceptors-*)
     export CLASSPATH="/etc/kafka-connect/jars/*:$REST_EXTENSION_JAR:$MONITORING_INTERCEPTOR_JAR"
 fi
 

--- a/replicator-executable/include/etc/confluent/docker/launch
+++ b/replicator-executable/include/etc/confluent/docker/launch
@@ -39,8 +39,8 @@ echo "===> Launching ${COMPONENT} ... "
 # And this also makes sure that the CLASSPATH does not start with ":/etc/..."
 # because this causes the plugin scanner to scan the entire disk.
 if [ -z "$CLASSPATH" ]; then
-    REST_EXTENSION_JAR=$(find /usr/share/java/kafka-connect-replicator/replicator-rest-extension-*jar)
-    MONITORING_INTERCEPTOR_JAR=$(find /usr/share/java/monitoring-interceptors/monitoring-interceptors-*)
+    REST_EXTENSION_JAR=$(ls /usr/share/java/kafka-connect-replicator/ | grep "replicator-rest-extension-")
+    MONITORING_INTERCEPTOR_JAR=$(ls /usr/share/java/kafka-connect-replicator/ | grep "monitoring-interceptors-")
     export CLASSPATH="/etc/kafka-connect/jars/*:$REST_EXTENSION_JAR:$MONITORING_INTERCEPTOR_JAR"
 fi
 

--- a/replicator/include/etc/confluent/docker/launch
+++ b/replicator/include/etc/confluent/docker/launch
@@ -39,8 +39,8 @@ echo "===> Launching ${COMPONENT} ... "
 # And this also makes sure that the CLASSPATH does not start with ":/etc/..."
 # because this causes the plugin scanner to scan the entire disk.
 if [ -z "$CLASSPATH" ]; then
-    REST_EXTENSION_JAR=$(find /usr/share/java/kafka-connect-replicator/replicator-rest-extension-*jar)
-    MONITORING_INTERCEPTOR_JAR=$(find /usr/share/java/monitoring-interceptors/monitoring-interceptors-*)
+    REST_EXTENSION_JAR=$(ls /usr/share/java/kafka-connect-replicator/ | grep "replicator-rest-extension-")
+    MONITORING_INTERCEPTOR_JAR=$(ls /usr/share/java/kafka-connect-replicator/ | grep "monitoring-interceptors-")
     export CLASSPATH="/etc/kafka-connect/jars/*:$REST_EXTENSION_JAR:$MONITORING_INTERCEPTOR_JAR"
 fi
 exec connect-distributed /etc/"${COMPONENT}"/"${COMPONENT}".properties

--- a/replicator/include/etc/confluent/docker/launch
+++ b/replicator/include/etc/confluent/docker/launch
@@ -39,8 +39,8 @@ echo "===> Launching ${COMPONENT} ... "
 # And this also makes sure that the CLASSPATH does not start with ":/etc/..."
 # because this causes the plugin scanner to scan the entire disk.
 if [ -z "$CLASSPATH" ]; then
-    REST_EXTENSION_JAR=$(ls -d /usr/share/java/kafka-connect-replicator/*replicator-rest-extension-*)
-    MONITORING_INTERCEPTOR_JAR=$(ls -d /usr/share/java/monitoring-interceptors/*monitoring-interceptors-*)
+    REST_EXTENSION_JAR=$(ls -d /usr/share/java/kafka-connect-replicator/*replicator-rest-extension-*jar)
+    MONITORING_INTERCEPTOR_JAR=$(ls -d /usr/share/java/monitoring-interceptors/*monitoring-interceptors-*jar)
     export CLASSPATH="/etc/kafka-connect/jars/*:$REST_EXTENSION_JAR:$MONITORING_INTERCEPTOR_JAR"
 fi
 exec connect-distributed /etc/"${COMPONENT}"/"${COMPONENT}".properties

--- a/replicator/include/etc/confluent/docker/launch
+++ b/replicator/include/etc/confluent/docker/launch
@@ -39,8 +39,8 @@ echo "===> Launching ${COMPONENT} ... "
 # And this also makes sure that the CLASSPATH does not start with ":/etc/..."
 # because this causes the plugin scanner to scan the entire disk.
 if [ -z "$CLASSPATH" ]; then
-    REST_EXTENSION_JAR=$(ls /usr/share/java/kafka-connect-replicator/ | grep "replicator-rest-extension-")
-    MONITORING_INTERCEPTOR_JAR=$(ls /usr/share/java/kafka-connect-replicator/ | grep "monitoring-interceptors-")
+    REST_EXTENSION_JAR=$(ls -d /usr/share/java/kafka-connect-replicator/*replicator-rest-extension-*)
+    MONITORING_INTERCEPTOR_JAR=$(ls -d /usr/share/java/monitoring-interceptors/*monitoring-interceptors-*)
     export CLASSPATH="/etc/kafka-connect/jars/*:$REST_EXTENSION_JAR:$MONITORING_INTERCEPTOR_JAR"
 fi
 exec connect-distributed /etc/"${COMPONENT}"/"${COMPONENT}".properties


### PR DESCRIPTION
As stated in https://confluentinc.atlassian.net/browse/ST-4314, we no longer include the `find` command in the base `ubi` images. As a result this `find` command can't be used to add the monitoring interceptors and replicator rest extension jar to the classpath. This PR remediates that by replacing `find` with `ls -d`.