### PR TITLE
Revert "REPL-1362: Replace find with ls -d"

### DIFF
--- a/replicator-executable/include/etc/confluent/docker/launch
+++ b/replicator-executable/include/etc/confluent/docker/launch
@@ -39,8 +39,8 @@ echo "===> Launching ${COMPONENT} ... "
 # And this also makes sure that the CLASSPATH does not start with ":/etc/..."
 # because this causes the plugin scanner to scan the entire disk.
 if [ -z "$CLASSPATH" ]; then
-    REST_EXTENSION_JAR=$(ls -d /usr/share/java/kafka-connect-replicator/*replicator-rest-extension-*jar)
-    MONITORING_INTERCEPTOR_JAR=$(ls -d /usr/share/java/monitoring-interceptors/*monitoring-interceptors-*jar)
+    REST_EXTENSION_JAR=$(find /usr/share/java/kafka-connect-replicator/replicator-rest-extension-*jar)
+    MONITORING_INTERCEPTOR_JAR=$(find /usr/share/java/monitoring-interceptors/monitoring-interceptors-*)
     export CLASSPATH="/etc/kafka-connect/jars/*:$REST_EXTENSION_JAR:$MONITORING_INTERCEPTOR_JAR"
 fi
 

--- a/replicator/include/etc/confluent/docker/launch
+++ b/replicator/include/etc/confluent/docker/launch
@@ -39,8 +39,8 @@ echo "===> Launching ${COMPONENT} ... "
 # And this also makes sure that the CLASSPATH does not start with ":/etc/..."
 # because this causes the plugin scanner to scan the entire disk.
 if [ -z "$CLASSPATH" ]; then
-    REST_EXTENSION_JAR=$(ls -d /usr/share/java/kafka-connect-replicator/*replicator-rest-extension-*jar)
-    MONITORING_INTERCEPTOR_JAR=$(ls -d /usr/share/java/monitoring-interceptors/*monitoring-interceptors-*jar)
+    REST_EXTENSION_JAR=$(find /usr/share/java/kafka-connect-replicator/replicator-rest-extension-*jar)
+    MONITORING_INTERCEPTOR_JAR=$(find /usr/share/java/monitoring-interceptors/monitoring-interceptors-*)
     export CLASSPATH="/etc/kafka-connect/jars/*:$REST_EXTENSION_JAR:$MONITORING_INTERCEPTOR_JAR"
 fi
 exec connect-distributed /etc/"${COMPONENT}"/"${COMPONENT}".properties


### PR DESCRIPTION
Reverts confluentinc/kafka-replicator-images#36

This PR getting merged in is suspiciously close to when the soak cluster and compatibility testing started getting broken with the following isuse:

```
[2021-02-24 18:04:54,933] ERROR WorkerConnector{id=replicator-soak-test} Error while starting connector (org.apache.kafka.connect.runtime.WorkerConnector)
org.apache.kafka.common.KafkaException: Failed to construct kafka producer
	at org.apache.kafka.clients.producer.KafkaProducer.<init>(KafkaProducer.java:440)
	at org.apache.kafka.clients.producer.KafkaProducer.<init>(KafkaProducer.java:291)
	at org.apache.kafka.clients.producer.KafkaProducer.<init>(KafkaProducer.java:274)
	at org.apache.kafka.connect.util.KafkaBasedLog.createProducer(KafkaBasedLog.java:272)
	at org.apache.kafka.connect.util.KafkaBasedLog.start(KafkaBasedLog.java:131)
	at io.confluent.license.LicenseStore.startLog(LicenseStore.java:258)
	at io.confluent.license.LicenseStore.start(LicenseStore.java:244)
	at io.confluent.license.LicenseManager.<init>(LicenseManager.java:225)
	at io.confluent.license.LicenseManager.<init>(LicenseManager.java:207)
	at io.confluent.license.LicenseManager.<init>(LicenseManager.java:147)
	at io.confluent.connect.replicator.ReplicatorSourceConnector.validateLicense(ReplicatorSourceConnector.java:197)
	at io.confluent.connect.replicator.ReplicatorSourceConnector.start(ReplicatorSourceConnector.java:91)
	at org.apache.kafka.connect.runtime.WorkerConnector.doStart(WorkerConnector.java:185)
	at org.apache.kafka.connect.runtime.WorkerConnector.start(WorkerConnector.java:210)
	at org.apache.kafka.connect.runtime.WorkerConnector.doTransitionTo(WorkerConnector.java:349)
	at org.apache.kafka.connect.runtime.WorkerConnector.doTransitionTo(WorkerConnector.java:332)
	at org.apache.kafka.connect.runtime.WorkerConnector.doRun(WorkerConnector.java:141)
	at org.apache.kafka.connect.runtime.WorkerConnector.run(WorkerConnector.java:118)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: org.apache.kafka.common.KafkaException: Could not instantiate class io.confluent.license.LicenseStore$LicenseKeySerde
	at org.apache.kafka.common.utils.Utils.newInstance(Utils.java:355)
	at org.apache.kafka.common.config.AbstractConfig.getConfiguredInstance(AbstractConfig.java:395)
	at org.apache.kafka.common.config.AbstractConfig.getConfiguredInstance(AbstractConfig.java:430)
	at org.apache.kafka.common.config.AbstractConfig.getConfiguredInstance(AbstractConfig.java:415)
	at org.apache.kafka.clients.producer.KafkaProducer.<init>(KafkaProducer.java:366)
	... 22 more
Caused by: java.lang.reflect.InvocationTargetException
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
	at org.apache.kafka.common.utils.Utils.newInstance(Utils.java:351)
	... 26 more
Caused by: java.lang.IncompatibleClassChangeError: Class io.confluent.command.record.Command$CommandKey does not implement the requested interface com.google.protobuf.Message
	at io.confluent.serializers.ProtoSerde.<init>(ProtoSerde.java:37)
	at io.confluent.license.LicenseStore$LicenseKeySerde.<init>(LicenseStore.java:231)
	... 31 more
[2021-02-24 18:04:54,984] ERROR [Worker clientId=connect-1, groupId=replicator-k8s] Failed to start connector 'replicator-soak-test' (org.apache.kafka.connect.runtime.distributed.DistributedHerder)
org.apache.kafka.connect.errors.ConnectException: Failed to start connector: replicator-soak-test
	at org.apache.kafka.connect.runtime.distributed.DistributedHerder.lambda$startConnector$4(DistributedHerder.java:1299)
	at org.apache.kafka.connect.runtime.WorkerConnector.doTransitionTo(WorkerConnector.java:335)
	at org.apache.kafka.connect.runtime.WorkerConnector.doRun(WorkerConnector.java:141)
	at org.apache.kafka.connect.runtime.WorkerConnector.run(WorkerConnector.java:118)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
```

I am reverting this PR to see if this will help.