### PR TITLE
Update Jenkinsfile Nodelabel

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,6 @@ docker_oraclejdk8 {
     dockerUpstreamTag = 'latest'  // Temporary; use trunk-latest when available
     mvnPhase = 'integration-test'
     mvnSkipDeploy = true
-    nodeLabel = 'docker-oraclejdk8-compose'
+    nodeLabel = 'docker-debian-jdk8-compose'
     withPush = true
 }


### PR DESCRIPTION
Update Jenkinsfile nodelabel to use new build image.

Context on new image: https://github.com/confluentinc/confluent-docker-build-images/pull/165/files

This will be pint merged up to master.