### PR TITLE
build: Remove confluent yum/apt repo after installation

### DIFF
--- a/replicator/Dockerfile.deb8
+++ b/replicator/Dockerfile.deb8
@@ -35,14 +35,14 @@ ARG ALLOW_UNSIGNED
 
 RUN echo "===> Installing Replicator ..." \
     && apt-get update \
+    && apt-get install -y apt-transport-https software-properties-common  \
     && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
-    && if [ "x$ALLOW_UNSIGNED" = "xtrue" ]; then echo "APT::Get::AllowUnauthenticated \"true\";" > /etc/apt/apt.conf.d/allow_unauthenticated; else curl -s -L ${CONFLUENT_PACKAGES_REPO}/archive.key -o /tmp/archive.key && apt-key add /tmp/archive.key; fi \
-    && echo "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" >> /etc/apt/sources.list \
-    && cat /etc/apt/sources.list \
-    && apt-get install -y apt-transport-https \
-    && apt-get -qq update \
+    && curl -s -L ${CONFLUENT_PACKAGES_REPO}/archive.key | apt-key add - \
+    && apt-add-repository "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" \
+    && apt-get update \
     && apt-get install -y confluent-kafka-connect-replicator=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     && echo "===> Cleaning up ..."  \
+    && apt-add-repository --remove "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" \
     && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/*
 
 COPY include/etc/confluent/docker /etc/confluent/docker

--- a/replicator/Dockerfile.ubi8
+++ b/replicator/Dockerfile.ubi8
@@ -21,6 +21,7 @@ FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-server-connect-base:${DOCKER_UPS
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
 ARG GIT_COMMIT
+ARG CONFLUENT_PACKAGES_REPO
 
 LABEL maintainer="partner-support@confluent.io"
 LABEL vendor="Confluent"

--- a/replicator/Dockerfile.ubi8
+++ b/replicator/Dockerfile.ubi8
@@ -39,11 +39,26 @@ ARG CONFLUENT_VERSION
 USER root
 
 RUN echo "===> Installing Replicator ..." \
+    && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
+    && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
+    && printf "[Confluent.dist] \n\
+name=Confluent repository (dist) \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/7 \n\
+gpgcheck=1 \n\
+gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
+enabled=1 \n\
+\n\
+[Confluent] \n\
+name=Confluent repository \n\
+baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
+gpgcheck=1 \n\
+gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
+enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && yum install -y \
         confluent-kafka-connect-replicator-${CONFLUENT_VERSION} \
     && echo "===> Cleaning up ..."  \
     && yum clean all \
-    && rm -rf /tmp/*
+    && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo
 
 COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker
 


### PR DESCRIPTION
Couple of changes:
* Remove confluent's repo config. Confluent's images don't need to be able to update to the next CP release (Customers should be consuming the next versioned docker release)
* Removed the AllowUnauthenticated piece: In practice, we always import the public key for GPG automation validation.
