### PR TITLE
REPL-1844: cp-enterprise-replicator-executable regression with 5.4.5

### DIFF
--- a/replicator-executable/include/etc/confluent/docker/launch
+++ b/replicator-executable/include/etc/confluent/docker/launch
@@ -35,14 +35,10 @@ if [ "x$KAFKA_JMX_PORT" != "x" ]; then
 fi
 
 echo "===> Launching ${COMPONENT} ... "
-# Add external jars, replicator monitoring and monitoring interceptors to the classpath
+# Add external jars to the classpath
 # And this also makes sure that the CLASSPATH does not start with ":/etc/..."
 # because this causes the plugin scanner to scan the entire disk.
-if [ -z "$CLASSPATH" ]; then
-    REST_EXTENSION_JAR=$(find /usr/share/java/kafka-connect-replicator/replicator-rest-extension-*jar)
-    MONITORING_INTERCEPTOR_JAR=$(find /usr/share/java/monitoring-interceptors/monitoring-interceptors-*)
-    export CLASSPATH="/etc/kafka-connect/jars/*:$REST_EXTENSION_JAR:$MONITORING_INTERCEPTOR_JAR"
-fi
+export CLASSPATH="/etc/kafka-connect/jars/*"
 
 # File properties
 export ARGS=""


### PR DESCRIPTION
This is same issue as REPL-1531 which was fixed with https://github.com/confluentinc/kafka-replicator-images/pull/39

Reverting commit for REPL-1224

Testing done:

creating image based on 5.4.5 and overriding launch file with the change from this PR:

```yml
FROM confluentinc/cp-enterprise-replicator-executable:5.4.5
COPY launch /etc/confluent/docker/launch
RUN ["chmod", "+x", "/etc/confluent/docker/launch"]
```

Using this custom image, my [test](https://github.com/vdesabou/kafka-docker-playground/tree/master/replicator/executable) is now working fine

