### PR TITLE
Enable arm64 builds for 7.0+

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,4 +15,5 @@ dockerfile {
     cpImages = true
     osTypes = ['ubi8']
     nanoVersion = true
+    buildArm = true
 }


### PR DESCRIPTION
As part of our plans to release ARM64 binaries and images for CP, we are enabling arm64 builds for versions 7.0+. This would be merged to 7.0.x and pint merged up to master. https://confluentinc.atlassian.net/browse/DP-5618