### PR TITLE
REPL-2844: added plain vanilla sempahore support

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -5,3 +5,17 @@ codeowners:
   enable: true
 git:
   enable: true
+semaphore:
+  enable: true
+  pipeline_type: cp-dockerfile
+  execution_time_limit: {"hours": 4}
+  docker_repos: ['confluentinc/cp-enterprise-replicator',
+                 'confluentinc/cp-enterprise-replicator-executable']
+  maven_phase: 'package'
+  maven_skip_deploy: true
+  os_types: ['ubi8']
+  nano_version: true
+  build_arm: true
+  use_packages: true
+  cp_images: true
+  


### PR DESCRIPTION
added plain vanilla sempahore support after creating the ecr repos for          

1.  'confluentinc/cp-enterprise-replicator': https://semaphore.ci.confluent.io/workflows/c2ac8eb1-4db4-466e-ac86-ac4361cc110b
2.  'confluentinc/cp-enterprise-replicator-executable': https://semaphore.ci.confluent.io/workflows/79021cc1-0472-41cd-8975-ffd4abc3c490