### PR TITLE
CPBR-2365: Upgrade component images to ubi9-minimal 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Properties are inherited from a top-level POM. Properties may be overridden on t
 - *docker.upstream-tag*: (Optional) Use the given tag when pulling base images. Used as `DOCKER_UPSTREAM_TAG` during `docker build`. Defaults to the value of `docker.tag`.
 - *docker.test-registry*: (Optional) Registry to pull test dependency images from. Trailing `/` is required. Used as `DOCKER_TEST_REGISTRY` during testing. Defaults to the value of `docker.upstream-registry`.
 - *docker.test-tag*: (Optional) Use the given tag when pulling test dependency images. Used as `DOCKER_TEST_TAG` during testing. Defaults to the value of `docker.upstream-tag`.
-- *docker.os_type*: (Optional) Specify which operating system to use as the base image by using the Dockerfile with this extension. Valid values are `ubi8`. Default value is `ubi8`.
+- *docker.os_type*: (Optional) Specify which operating system to use as the base image by using the Dockerfile with this extension. Valid values are `ubi9`. Default value is `ubi9`.
 - *CONFLUENT_PACKAGES_REPO*: (Required) Specify the location of the Confluent Platform packages repository. Depending on the type of OS for the image you are building you will need to either provide a Debian or RPM repository. For example this is the repository for the 5.4.0 release of the Debian packages: `https://s3-us-west-2.amazonaws.com/confluent-packages-5.4.0/deb/5.4` This is the repository for the 5.4.0 release of the RPM's: `https://s3-us-west-2.amazonaws.com/confluent-packages-5.4.0/rpm/5.4`
 - *CONFLUENT_VERSION*: (Required) Specify the full Confluent Platform release version. Example: 5.4.0
 

--- a/replicator-executable/Dockerfile.ubi9
+++ b/replicator-executable/Dockerfile.ubi9
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 ARG DOCKER_REGISTRY
-ARG DOCKER_UPSTREAM_TAG=ubi8-latest
+ARG DOCKER_UPSTREAM_TAG=ubi9-latest
 ARG DOCKER_TAG
 
 FROM ${DOCKER_REGISTRY}confluentinc/cp-enterprise-replicator:${DOCKER_TAG}

--- a/replicator/Dockerfile.ubi9
+++ b/replicator/Dockerfile.ubi9
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 ARG DOCKER_UPSTREAM_REGISTRY
-ARG DOCKER_UPSTREAM_TAG=ubi8-latest
+ARG DOCKER_UPSTREAM_TAG=ubi9-latest
 
 FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-server-connect-base:${DOCKER_UPSTREAM_TAG}
 

--- a/replicator/Dockerfile.ubi9
+++ b/replicator/Dockerfile.ubi9
@@ -42,14 +42,7 @@ USER root
 RUN echo "===> Installing Replicator ..." \
     && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
     && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
-    && printf "[Confluent.dist] \n\
-name=Confluent repository (dist) \n\
-baseurl=${CONFLUENT_PACKAGES_REPO}/7 \n\
-gpgcheck=1 \n\
-gpgkey=${CONFLUENT_PACKAGES_REPO}/archive.key \n\
-enabled=1 \n\
-\n\
-[Confluent] \n\
+    && printf "[Confluent] \n\
 name=Confluent repository \n\
 baseurl=${CONFLUENT_PACKAGES_REPO}/ \n\
 gpgcheck=1 \n\

--- a/service.yml
+++ b/service.yml
@@ -13,7 +13,7 @@ semaphore:
                  'confluentinc/cp-enterprise-replicator-executable']
   maven_phase: 'package'
   maven_skip_deploy: true
-  os_types: ['ubi8']
+  os_types: ['ubi9']
   nano_version: true
   build_arm: true
   use_packages: true


### PR DESCRIPTION
[cp-base-new](https://confluentinc.atlassian.net/browse/CP-base-new) is upgraded to ubi9-minimal in https://github.com/confluentinc/common-docker/pull/668
CP images are being upgraded to ubi9
Semaphore pipeline changes will be brought in using servicebot (eg. https://github.com/confluentinc/common-docker/pull/693)