### PR TITLE
CPBR-2895 update log4j2 and properties templates

### DIFF
--- a/replicator-executable/include/etc/confluent/docker/log4j2.yaml.template
+++ b/replicator-executable/include/etc/confluent/docker/log4j2.yaml.template
@@ -1,0 +1,31 @@
+Configuration:
+  name: "Log4j2"
+
+  Appenders:
+    Console:
+      name: STDOUT
+      target: SYSTEM_OUT
+      PatternLayout:
+        Pattern: "[%d] %p %m (%c)%n"
+
+  Loggers:
+    Root:
+      level: {{ getEnv "REPLICATOR_LOG4J_ROOT_LOGLEVEL" "INFO" }}
+      AppenderRef:
+        - ref: STDOUT
+
+    Logger:
+    {{- if getEnv "REPLICATOR_LOG4J_LOGGERS" "" }}
+    {{- $loggers := getEnv "REPLICATOR_LOG4J_LOGGERS" "" -}}
+    {{- range $logger, $loglevel := splitToMapDefaults ","  "" $loggers}}
+      - name: "{{ $logger }}"
+        level: "{{ $loglevel }}"
+        AppenderRef:
+          ref: STDOUT
+    {{- end }}
+    {{- else }}
+      - name: "org.reflections"
+        level: "ERROR"
+        AppenderRef:
+          ref: STDOUT
+    {{- end }} 

--- a/replicator/include/etc/confluent/docker/kafka-connect.properties.template
+++ b/replicator/include/etc/confluent/docker/kafka-connect.properties.template
@@ -1,4 +1,4 @@
-{% set connect_props = env_to_props('CONNECT_', '') -%}
-{% for name, value in connect_props.items() -%}
-{{name}}={{value}}
-{% endfor -%}
+{{- $connect_props := envToProps "CONNECT_" "" nil nil nil -}}
+{{ range $k, $v := $connect_props }}
+{{ $k }}={{ $v }}
+{{ end }}

--- a/replicator/include/etc/confluent/docker/log4j2.yaml.template
+++ b/replicator/include/etc/confluent/docker/log4j2.yaml.template
@@ -1,0 +1,31 @@
+Configuration:
+  name: "Log4j2"
+
+  Appenders:
+    Console:
+      name: STDOUT
+      target: SYSTEM_OUT
+      PatternLayout:
+        Pattern: "{{ getEnv \"CONNECT_LOG4J_APPENDER_STDOUT_LAYOUT_CONVERSIONPATTERN\" \"[%d] %p %m (%c)%n\" }}"
+
+  Loggers:
+    Root:
+      level: {{ getEnv "CONNECT_LOG4J_ROOT_LOGLEVEL" "INFO" }}
+      AppenderRef:
+        - ref: STDOUT
+
+    Logger:
+    {{- if getEnv "CONNECT_LOG4J_LOGGERS" "" }}
+    {{- $loggers := getEnv "CONNECT_LOG4J_LOGGERS" "" -}}
+    {{- range $logger, $loglevel := splitToMapDefaults ","  "" $loggers}}
+      - name: "{{ $logger }}"
+        level: "{{ $loglevel }}"
+        AppenderRef:
+          ref: STDOUT
+    {{- end }}
+    {{- else }}
+      - name: "org.reflections"
+        level: "ERROR"
+        AppenderRef:
+          ref: STDOUT
+    {{- end }} 


### PR DESCRIPTION
This PR 
1. migrates the logging configs to log4j2 
2. modifies the kafka-connect properties file to be parsable by ub and use appropriate ub utilities 