### PR TITLE
chore: remove dead Spotify plugin config from replicator/pom.xml

### DIFF
--- a/replicator/pom.xml
+++ b/replicator/pom.xml
@@ -56,15 +56,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
-                <configuration>
-                    <buildArgs>
-                        <UBI9_VERSION>${ubi9.image.version}</UBI9_VERSION>
-                    </buildArgs>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
                 <configuration>


### PR DESCRIPTION
## Summary
- Removes dead Spotify `dockerfile-maven-plugin` config block from `replicator/pom.xml`
- Common-docker parent already binds this plugin to `<phase>none</phase>`, so the block never executed
- Fabric8 is the active docker builder; no behavioral change

## Test plan
- [ ] Build succeeds on 8.3.x pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)