### PR TITLE
CPBR-3942: Build replicator from cp-server-connect instead of cp-server-connect-base

### DIFF
--- a/replicator/Dockerfile.ubi9
+++ b/replicator/Dockerfile.ubi9
@@ -17,8 +17,8 @@ ARG DOCKER_UPSTREAM_REGISTRY
 ARG DOCKER_UPSTREAM_TAG=ubi9-latest
 ARG UBI9_VERSION
 
-# Stage 1: Get package_dedupe tool from cp-server-connect-base
-FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-server-connect-base:${DOCKER_UPSTREAM_TAG} AS tools
+# Stage 1: Get package_dedupe tool from cp-server-connect
+FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-server-connect:${DOCKER_UPSTREAM_TAG} AS tools
 
 # Stage 2: Install packages using ubi9 with dnf to /microdir
 FROM registry.access.redhat.com/ubi9:${UBI9_VERSION} AS builder
@@ -57,8 +57,8 @@ RUN echo "===> Installing packages to /microdir with dnf" \
              /microdir/etc/subuid /microdir/etc/subgid \
     && rm -rf /microdir/dev/* /microdir/proc/* /microdir/sys/*
 
-# Stage 3: Final image inheriting from cp-server-connect-base
-FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-server-connect-base:${DOCKER_UPSTREAM_TAG}
+# Stage 3: Final image inheriting from cp-server-connect
+FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-server-connect:${DOCKER_UPSTREAM_TAG}
 
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID


### PR DESCRIPTION
**Why**

`cp-server-connect-base` is being removed from `kafka-images` — it's functionally identical to `cp-server-connect`, which now carries the same build logic directly rather than through a separate base image. This repo's replicator build pulls `cp-server-connect-base` in two Dockerfile stages, so it needs to move to the plain image name before that removal lands.

**What**

Both `FROM` stages (the `package_dedupe` tool stage and the final image) now pull `cp-server-connect` instead. No other build logic changes.

Confirmed in the `kafka-images` change ([confluentinc/kafka-images#505](https://github.com/confluentinc/kafka-images/pull/505)) that `cp-server-connect`'s labels, env, entrypoint, and installed files are identical to what `cp-server-connect-base` currently ships, so this is a drop-in swap.